### PR TITLE
Log authentication errors as errors instead of debug

### DIFF
--- a/ngx_http_auth_pam_module.c
+++ b/ngx_http_auth_pam_module.c
@@ -335,7 +335,7 @@ ngx_http_auth_pam_authenticate(ngx_http_request_t *r,
                         (const char *) ainfo.username.data,
                         &conv_info,
                         &pamh)) != PAM_SUCCESS) {
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+        ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0,
                       "PAM: Could not start pam service: %s",
                       pam_strerror(pamh, rc));
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
@@ -348,7 +348,7 @@ ngx_http_auth_pam_authenticate(ngx_http_request_t *r,
     /* try to authenticate user, log error on failure */
     if ((rc = pam_authenticate(pamh,
                                PAM_DISALLOW_NULL_AUTHTOK)) != PAM_SUCCESS) {
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "PAM: user '%s' - not authenticated: %s",
                       ainfo.username.data, pam_strerror(pamh, rc));
         pam_end(pamh, PAM_SUCCESS);
@@ -357,8 +357,8 @@ ngx_http_auth_pam_authenticate(ngx_http_request_t *r,
 
     /* check that the account is healthy */
     if ((rc = pam_acct_mgmt(pamh, PAM_DISALLOW_NULL_AUTHTOK)) != PAM_SUCCESS) {
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                      "PAM: user '%s'  - invalid account: %s",
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                      "PAM: user '%s' - invalid account: %s",
                       ainfo.username.data, pam_strerror(pamh, rc));
         pam_end(pamh, PAM_SUCCESS);
         return ngx_http_auth_pam_set_realm(r, &alcf->realm);


### PR DESCRIPTION
This PR changes the log level of the authentication error messages to error instead of debug. They are now logged similarly like in the http auth basic module.
