### PR TITLE
Log authentication errors with an error level of error instead of debug

### DIFF
--- a/ngx_http_auth_pam_module.c
+++ b/ngx_http_auth_pam_module.c
@@ -348,7 +348,7 @@ ngx_http_auth_pam_authenticate(ngx_http_request_t *r,
     /* try to authenticate user, log error on failure */
     if ((rc = pam_authenticate(pamh,
                                PAM_DISALLOW_NULL_AUTHTOK)) != PAM_SUCCESS) {
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "PAM: user '%s' - not authenticated: %s",
                       ainfo.username.data, pam_strerror(pamh, rc));
         pam_end(pamh, PAM_SUCCESS);
@@ -357,7 +357,7 @@ ngx_http_auth_pam_authenticate(ngx_http_request_t *r,
 
     /* check that the account is healthy */
     if ((rc = pam_acct_mgmt(pamh, PAM_DISALLOW_NULL_AUTHTOK)) != PAM_SUCCESS) {
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                       "PAM: user '%s'  - invalid account: %s",
                       ainfo.username.data, pam_strerror(pamh, rc));
         pam_end(pamh, PAM_SUCCESS);


### PR DESCRIPTION
This properly fixes #1. 613218f763e292f23ad196014e4dd69611f9c90c added
logs for some messages but left authentication errors at a debug log
level.

@AndreLouisCaron I was not looking at the right part of the code, this is what will make logs work.