### PR TITLE
always load after ngx_http_access_module

### DIFF
--- a/config
+++ b/config
@@ -7,6 +7,7 @@ if test -n "$ngx_module_link"; then
     ngx_module_deps=
     ngx_module_srcs="$ngx_addon_dir/ngx_http_auth_pam_module.c"
     ngx_module_libs="-lpam"
+    ngx_module_order="$ngx_module_name ngx_http_access_module"
 
     . auto/module
 else


### PR DESCRIPTION
resolves https://github.com/sto/ngx_http_auth_pam_module/issues/25

i have verified the following in production:

- `deny` rules to evaluate before pam auth, returning 403 immediately
- when no deny rule is present, 401 is returned
- when valid http basic auth creds are supplied, 200 is returned
- when invalid http basic auth creds are supplied, 401 is returned